### PR TITLE
fix: Corrige URL da API e configura CORS no backend

### DIFF
--- a/frontend/nginx.conf
+++ b/frontend/nginx.conf
@@ -6,16 +6,6 @@ server {
     root /usr/share/nginx/html;
     index index.html index.htm;
 
-    # Rota para a API (proxy reverso)
-    location /api/ {
-        # O nome 'cnd' vem do nome do serviço no docker-compose.yml
-        proxy_pass http://cnd:8080/;
-        proxy_set_header Host $host;
-        proxy_set_header X-Real-IP $remote_addr;
-        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        proxy_set_header X-Forwarded-Proto $scheme;
-    }
-
     # Rota para a aplicação React (Single Page Application)
     location / {
         try_files $uri /index.html;

--- a/frontend/src/components/ClientForm.js
+++ b/frontend/src/components/ClientForm.js
@@ -75,9 +75,9 @@ const ClientForm = ({ clientToEdit, onFormSubmit }) => {
 
     try {
       if (clientToEdit) {
-        await axios.put(`/api/clientes/${clientToEdit.id}`, payload);
+        await axios.put(`http://localhost:8080/clientes/${clientToEdit.id}`, payload, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
       } else {
-        await axios.post('/api/clientes', payload);
+        await axios.post('http://localhost:8080/clientes', payload, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
       }
       onFormSubmit();
     } catch (error) {

--- a/frontend/src/components/CndMonitor.js
+++ b/frontend/src/components/CndMonitor.js
@@ -65,7 +65,7 @@ const CndMonitor = () => {
   const fetchResults = async () => {
     setLoading(true);
     try {
-      const response = await axios.get('/api/clientes');
+      const response = await axios.get('http://localhost:8080/clientes', { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
       const mockedResults = response.data.map(cliente => ({
         id: cliente.id,
         dataProcessamento: new Date().toISOString(),
@@ -134,7 +134,7 @@ const CndMonitor = () => {
   const confirmDelete = async () => {
     if (!selectedResult) return;
     try {
-      await axios.delete(`/api/clientes/${selectedResult.cliente.id}`);
+      await axios.delete(`http://localhost:8080/clientes/${selectedResult.cliente.id}`, { headers: { 'X-Requested-With': 'XMLHttpRequest' } });
       fetchResults();
     } catch (error) {
       console.error('Erro ao excluir:', error);

--- a/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/config/WebConfig.java
+++ b/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/config/WebConfig.java
@@ -1,0 +1,24 @@
+package br.com.sisaudcon.saam.saam_sped_cnd.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig {
+
+    @Bean
+    public WebMvcConfigurer corsConfigurer() {
+        return new WebMvcConfigurer() {
+            @Override
+            public void addCorsMappings(CorsRegistry registry) {
+                registry.addMapping("/**")
+                        .allowedOrigins("http://localhost:3000")
+                        .allowedMethods("GET", "POST", "PUT", "DELETE", "OPTIONS")
+                        .allowedHeaders("*")
+                        .allowCredentials(true);
+            }
+        };
+    }
+}


### PR DESCRIPTION
- Remove o prefixo `/api` incorreto das chamadas no frontend.
- Simplifica a configuração do Nginx, removendo o proxy reverso desnecessário.
- Adiciona uma configuração global de CORS no backend Spring para permitir requisições do frontend (`localhost:3000`).
- Esta correção resolve os erros 404 e potenciais erros de CORS, garantindo a comunicação correta entre o frontend e o backend no ambiente Docker.