### PR TITLE
fix: Configura Spring Security para permitir CORS

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -37,6 +37,11 @@
 
 		<dependency>
 			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-test</artifactId>
 			<scope>test</scope>
 		</dependency>

--- a/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/config/SecurityConfig.java
+++ b/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/config/SecurityConfig.java
@@ -1,0 +1,34 @@
+package br.com.sisaudcon.saam.saam_sped_cnd.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.HttpMethod;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+            // Desabilitar CSRF, pois a aplicação é stateless (sem sessão no backend)
+            .csrf(csrf -> csrf.disable())
+
+            // Configurar a política de sessão para ser stateless
+            .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
+            // Configurar as regras de autorização para as requisições HTTP
+            .authorizeHttpRequests(authorize -> authorize
+                // Permitir requisições OPTIONS para todas as rotas (essencial para CORS preflight)
+                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
+                // Permitir todas as outras requisições (ajuste conforme a necessidade de segurança)
+                .anyRequest().permitAll()
+            );
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
- Adiciona a dependência do Spring Boot Starter Security.
- Cria a classe SecurityConfig para desabilitar CSRF e permitir requisições OPTIONS (preflight do CORS), que estavam sendo bloqueadas e causando o erro 403 Forbidden.
- A configuração de WebConfig (CORS) é mantida e agora funciona em conjunto com a nova camada de segurança.
- Esta alteração resolve o problema de CORS que impedia o frontend de se comunicar com o backend.