### PR TITLE
fix: Centraliza configuração de CORS no Spring Security

### DIFF
--- a/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/config/SecurityConfig.java
+++ b/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/config/SecurityConfig.java
@@ -7,6 +7,12 @@ import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
 import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.web.cors.CorsConfiguration;
+import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
+import org.springframework.web.filter.CorsFilter;
+import org.springframework.context.annotation.Bean;
+
+import java.util.Arrays;
 
 @Configuration
 @EnableWebSecurity
@@ -15,20 +21,26 @@ public class SecurityConfig {
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-            // Desabilitar CSRF, pois a aplicação é stateless (sem sessão no backend)
+            .cors(cors -> cors.configurationSource(corsConfigurationSource()))
             .csrf(csrf -> csrf.disable())
-
-            // Configurar a política de sessão para ser stateless
             .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
-
-            // Configurar as regras de autorização para as requisições HTTP
             .authorizeHttpRequests(authorize -> authorize
-                // Permitir requisições OPTIONS para todas as rotas (essencial para CORS preflight)
-                .requestMatchers(HttpMethod.OPTIONS, "/**").permitAll()
-                // Permitir todas as outras requisições (ajuste conforme a necessidade de segurança)
                 .anyRequest().permitAll()
             );
 
         return http.build();
+    }
+
+    @Bean
+    public UrlBasedCorsConfigurationSource corsConfigurationSource() {
+        CorsConfiguration configuration = new CorsConfiguration();
+        configuration.setAllowedOrigins(Arrays.asList("http://localhost:3000"));
+        configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "OPTIONS"));
+        configuration.setAllowedHeaders(Arrays.asList("*"));
+        configuration.setAllowCredentials(true);
+
+        UrlBasedCorsConfigurationSource source = new UrlBasedCorsConfigurationSource();
+        source.registerCorsConfiguration("/**", configuration);
+        return source;
     }
 }


### PR DESCRIPTION
- Modifica a classe SecurityConfig para gerenciar o CORS diretamente, que é a abordagem padrão e mais robusta.
- Remove a classe WebConfig duplicada para evitar conflitos de configuração.
- Esta alteração visa resolver definitivamente os erros de CORS, garantindo que as requisições do frontend sejam corretamente autorizadas pelo backend.