### PR TITLE
fix: Remove importação do index.css

### DIFF
--- a/frontend/src/index.js
+++ b/frontend/src/index.js
@@ -1,6 +1,5 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import './index.css';
 import App from './App';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));


### PR DESCRIPTION
- Remove a linha `import './index.css';` do arquivo `src/index.js`.
- Esta correção resolve o erro de build 'Module not found' que ocorria após a remoção do arquivo CSS, permitindo que a imagem Docker do frontend seja construída com sucesso.