### PR TITLE
Fix: Corrige o manuseio do ID do cliente no frontend

### DIFF
--- a/frontend/src/components/ClientForm.js
+++ b/frontend/src/components/ClientForm.js
@@ -45,12 +45,13 @@ const ClientForm = ({ clientToEdit, onCreate, onUpdate, onClose, isOpen }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (clientToEdit && !clientToEdit.id) {
+    if (clientToEdit && !formData.id) {
         console.error("Tentativa de atualização sem ID de cliente.");
         return; // Salvaguarda para não enviar requisição sem ID
     }
 
     const payload = {
+      id: formData.id,
       cnpj: formData.cnpj,
       periodicidade: formData.periodicidade,
       statusCliente: formData.statusCliente,
@@ -65,7 +66,7 @@ const ClientForm = ({ clientToEdit, onCreate, onUpdate, onClose, isOpen }) => {
     };
 
     if (clientToEdit) {
-      onUpdate(clientToEdit.id, payload);
+      onUpdate(formData.id, payload);
     } else {
       onCreate(payload);
     }

--- a/frontend/src/pages/CNDMonitoramento.js
+++ b/frontend/src/pages/CNDMonitoramento.js
@@ -61,10 +61,9 @@ const CNDMonitoramento = () => {
         try {
             await axios.delete(`/api/clientes/${clientToDelete.id}`);
             fetchClients();
+            setClientToDelete(null); // Fechar o modal de confirmação
         } catch (error) {
             console.error("Erro ao excluir cliente:", error);
-        } finally {
-            setClientToDelete(null);
         }
     };
 


### PR DESCRIPTION
Esta correção aborda a falta do ID do cliente nas solicitações de atualização e exclusão, o que causava erros. As seguintes alterações foram feitas:

- `CNDMonitoramento.js`: A função `handleDelete` foi ajustada para garantir que o modal de confirmação seja fechado após a exclusão bem-sucedida.
- `ClientForm.js`: A função `handleSubmit` foi modificada para usar o `id` do cliente do estado do formulário (`formData`) ao atualizar um cliente, garantindo que o `id` correto seja enviado na requisição `PUT`.