### PR TITLE
Fix: Adiciona ID do cliente na resposta da API GET /clientes

### DIFF
--- a/src/test/java/br/com/sisaudcon/saam/saam_sped_cnd/controller/ClienteControllerTest.java
+++ b/src/test/java/br/com/sisaudcon/saam/saam_sped_cnd/controller/ClienteControllerTest.java
@@ -1,0 +1,60 @@
+package br.com.sisaudcon.saam.saam_sped_cnd.controller;
+
+import br.com.sisaudcon.saam.saam_sped_cnd.domain.model.Cliente;
+import br.com.sisaudcon.saam.saam_sped_cnd.domain.model.Empresa;
+import br.com.sisaudcon.saam.saam_sped_cnd.domain.repository.ClienteRepository;
+import br.com.sisaudcon.saam.saam_sped_cnd.domain.repository.EmpresaRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@SpringBootTest
+@AutoConfigureMockMvc
+public class ClienteControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @Autowired
+    private ClienteRepository clienteRepository;
+
+    @Autowired
+    private EmpresaRepository empresaRepository;
+
+    @BeforeEach
+    public void setUp() {
+        clienteRepository.deleteAll();
+        empresaRepository.deleteAll();
+    }
+
+    @Test
+    public void deveRetornarIdNaListaDeClientes() throws Exception {
+        Empresa empresa = new Empresa();
+        empresa.setIdEmpresa("TESTE");
+        empresa.setCnpj("00.000.000/0000-00");
+        empresa.setNomeEmpresa("Empresa Teste");
+        empresaRepository.save(empresa);
+
+        Cliente cliente = new Cliente();
+        cliente.setCnpj("06.988.594/0001-77");
+        cliente.setPeriodicidade(30);
+        cliente.setStatusCliente("ATIVO");
+        cliente.setNacional(true);
+        cliente.setMunicipal(true);
+        cliente.setEstadual(false);
+        cliente.setEmpresa(empresa);
+        clienteRepository.save(cliente);
+
+        mockMvc.perform(get("/clientes"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").exists())
+                .andExpect(jsonPath("$[0].cnpj").value("06.988.594/0001-77"));
+    }
+}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -4,4 +4,4 @@ spring.datasource.username=sa
 spring.datasource.password=password
 spring.jpa.database-platform=org.hibernate.dialect.H2Dialect
 saam.validation.url=http://localhost:8080/validate
-cnd.resultado.scheduled.cron=0 0 5 L 12 ?
+cnd.resultado.scheduled.cron=0 0 1 1 1 *


### PR DESCRIPTION
- Altera a anotação no ClienteDTO de @Data para @Getter e @Setter para garantir a serialização correta do campo 'id'.
- Adiciona configuração de teste (application.properties e dependência H2) para permitir a execução dos testes em um ambiente isolado.
- Adiciona teste de integração para verificar a presença do campo 'id' na resposta da API.