### PR TITLE
feat(frontend): Implement JWT token handling from URL

### DIFF
--- a/frontend/src/pages/CNDMonitoramento.js
+++ b/frontend/src/pages/CNDMonitoramento.js
@@ -20,6 +20,24 @@ const CNDMonitoramento = () => {
 
     // --- LÓGICA DE DADOS (CRUD) ---
     useEffect(() => {
+        // 1. Extrair e configurar o token JWT
+        const urlParams = new URLSearchParams(window.location.search);
+        const token = urlParams.get('token');
+
+        if (token) {
+            // Armazena o token para persistência (recarregar a página não vai te deslogar)
+            localStorage.setItem('jwtToken', token);
+            // Limpa a URL para que o token não fique exposto
+            window.history.replaceState({}, document.title, window.location.pathname);
+        }
+
+        const storedToken = localStorage.getItem('jwtToken');
+        if (storedToken) {
+            // Configura o cabeçalho de autorização para todas as futuras requisições do axios
+            axios.defaults.headers.common['Authorization'] = `Bearer ${storedToken}`;
+        }
+
+        // 2. Agora, busca os clientes
         fetchClients();
     }, []);
 


### PR DESCRIPTION
- Adds logic to CNDMonitoramento page to read a JWT token from the URL parameters on initial load.
- Stores the retrieved token in localStorage for persistent authentication.
- Configures axios to automatically send the Authorization: Bearer <token> header on all subsequent API requests.
- Cleans the token from the browser's URL for security and usability.