### PR TITLE
fix(security): Implement Spring Security to protect API endpoints

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -96,6 +96,10 @@
 			<artifactId>java-jwt</artifactId>
 			<version>4.5.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-security</artifactId>
+		</dependency>
 	</dependencies>
 
 	<build>

--- a/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/config/SecurityConfig.java
+++ b/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/config/SecurityConfig.java
@@ -1,0 +1,39 @@
+package br.com.sisaudcon.saam.saam_sped_cnd.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import br.com.sisaudcon.saam.saam_sped_cnd.security.JwtAuthenticationFilter;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+public class SecurityConfig {
+
+    private final JwtAuthenticationFilter jwtAuthenticationFilter;
+
+    public SecurityConfig(JwtAuthenticationFilter jwtAuthenticationFilter) {
+        this.jwtAuthenticationFilter = jwtAuthenticationFilter;
+    }
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(csrf -> csrf.disable())
+                .sessionManagement(session -> session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers("/empresas/**", "/clientes/**").authenticated()
+                        .anyRequest().permitAll()
+                )
+                .addFilterBefore(jwtAuthenticationFilter, UsernamePasswordAuthenticationFilter.class);
+
+        return http.build();
+    }
+}

--- a/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/controller/EmpresaController.java
+++ b/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/controller/EmpresaController.java
@@ -1,18 +1,19 @@
 package br.com.sisaudcon.saam.saam_sped_cnd.controller;
 import br.com.sisaudcon.saam.saam_sped_cnd.dto.IntegracaoEmpresa;
 import br.com.sisaudcon.saam.saam_sped_cnd.integracao.EmpresaSaamService;
-import br.com.sisaudcon.saam.saam_sped_cnd.security.JwtTokenDecoder;
+import br.com.sisaudcon.saam.saam_sped_cnd.dto.IntegracaoEmpresa;
+import br.com.sisaudcon.saam.saam_sped_cnd.integracao.EmpresaSaamService;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.validation.annotation.Validated;
-
-import jakarta.validation.constraints.NotBlank;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestHeader;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 import java.util.List;
+
 @RestController
 @RequestMapping("/empresas")
 @Validated
@@ -20,41 +21,32 @@ import java.util.List;
 public class EmpresaController {
 
     private final EmpresaSaamService empresasSaam;
-    private final JwtTokenDecoder jwtTokenDecoder;
 
-    public EmpresaController(EmpresaSaamService empresasSaam, JwtTokenDecoder jwtTokenDecoder) {
+    public EmpresaController(EmpresaSaamService empresasSaam) {
         this.empresasSaam = empresasSaam;
-        this.jwtTokenDecoder = jwtTokenDecoder;
     }
 
     /**
      * Retorna a lista de empresas integradas para um cliente SAAM.
+     * O ID do cliente é extraído do token JWT validado pelo Spring Security.
      *
-     * @param tokenHeader Header JWT enviado no header Authorization.
      * @return Lista de empresas vinculadas.
      */
     @GetMapping
-    public ResponseEntity<?> listarEmpresasPorCliente(
-            @RequestHeader("Authorization") @NotBlank String tokenHeader) {
-        try {
-            String token = tokenHeader.replace("Bearer ", "");
-            String idClienteSaam = jwtTokenDecoder.extrairClientId(token);
+    public ResponseEntity<?> listarEmpresasPorCliente() {
+        Authentication authentication = SecurityContextHolder.getContext().getAuthentication();
+        String idClienteSaam = authentication.getName();
 
-            log.info("Token válido. Buscando empresas para o cliente SAAM ID: {}", idClienteSaam);
+        log.info("Buscando empresas para o cliente SAAM ID: {}", idClienteSaam);
 
-            List<IntegracaoEmpresa> empresas = empresasSaam.obterListaDeEmpresasDoSaam(idClienteSaam);
+        List<IntegracaoEmpresa> empresas = empresasSaam.obterListaDeEmpresasDoSaam(idClienteSaam);
 
-            if (empresas == null || empresas.isEmpty()) {
-                log.warn("Nenhuma empresa encontrada para o cliente SAAM ID: {}", idClienteSaam);
-                return ResponseEntity.noContent().build();
-            }
-
-            return ResponseEntity.ok(empresas);
-
-        } catch (Exception e) {
-            log.error("Erro ao processar token ou buscar empresas: {}", e.getMessage(), e);
-            return ResponseEntity.status(401).body("Token inválido ou expirado.");
+        if (empresas == null || empresas.isEmpty()) {
+            log.warn("Nenhuma empresa encontrada para o cliente SAAM ID: {}", idClienteSaam);
+            return ResponseEntity.noContent().build();
         }
+
+        return ResponseEntity.ok(empresas);
     }
 }
 

--- a/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/security/JwtAuthenticationFilter.java
+++ b/src/main/java/br/com/sisaudcon/saam/saam_sped_cnd/security/JwtAuthenticationFilter.java
@@ -1,0 +1,53 @@
+package br.com.sisaudcon.saam.saam_sped_cnd.security;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.User;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.stereotype.Component;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+import java.util.ArrayList;
+
+@Component
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private final JwtTokenDecoder jwtTokenDecoder;
+
+    public JwtAuthenticationFilter(JwtTokenDecoder jwtTokenDecoder) {
+        this.jwtTokenDecoder = jwtTokenDecoder;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain)
+            throws ServletException, IOException {
+
+        String header = request.getHeader("Authorization");
+
+        if (header == null || !header.startsWith("Bearer ")) {
+            filterChain.doFilter(request, response);
+            return;
+        }
+
+        String token = header.substring(7);
+        try {
+            String clientId = jwtTokenDecoder.extrairClientId(token);
+
+            if (clientId != null && SecurityContextHolder.getContext().getAuthentication() == null) {
+                UserDetails userDetails = new User(clientId, "", new ArrayList<>());
+                UsernamePasswordAuthenticationToken authentication = new UsernamePasswordAuthenticationToken(
+                        userDetails, null, userDetails.getAuthorities());
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            // Token inválido, não faz nada, a requisição não será autenticada
+        }
+
+        filterChain.doFilter(request, response);
+    }
+}


### PR DESCRIPTION
- Adds spring-boot-starter-security dependency to pom.xml.
- Creates SecurityConfig to enable web security and define authorization rules, requiring authentication for /clientes/** and /empresas/**.
- Implements JwtAuthenticationFilter to extract, validate, and process JWT tokens from the Authorization header for every request.
- Integrates the JwtAuthenticationFilter into the Spring Security filter chain.
- Refactors EmpresaController to remove manual token handling and rely on the security context provided by the framework.

This resolves a critical security vulnerability where API endpoints were accessible without any authentication.